### PR TITLE
Use new timeago.js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "union": "0.3.7",
         "ejdb": "1.1.6-0",
         "stylus": "0.32.1",
-        "timeago": "0.1.0",
+        "timeago.js": "2.0.3",
         "connect-baddies": "0.0.3"
     },
     "repository": {

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -12,7 +12,7 @@ path       = require 'path'
 eco        = require 'eco'
 fs         = require 'fs'
 stylus     = require 'stylus'
-timeago    = require 'timeago'
+timeago    = new require 'timeago' 
 baddies    = require 'connect-baddies'
 
 pkg = require '../package.json'
@@ -217,7 +217,7 @@ respond = (res, week) ->
                 if (time = new Date message.time) # parse time
                     message.time =
                         'iso': time.toISOString()
-                        'formatted': ago = timeago time
+                        'formatted': ago = timeago.format time
                         'today': /hour|minute/i.test ago
                 data.push message
 

--- a/src/service.coffee
+++ b/src/service.coffee
@@ -12,7 +12,7 @@ path       = require 'path'
 eco        = require 'eco'
 fs         = require 'fs'
 stylus     = require 'stylus'
-timeago    = new require 'timeago' 
+timeago    = new require 'timeago.js' 
 baddies    = require 'connect-baddies'
 
 pkg = require '../package.json'


### PR DESCRIPTION
Replace the heavy jQuery.timeago plugin with a smaller library named [timeago.js](http://timeago.org/).

This library is ~2KB, has no dependencies and includes several built-in locales. It also updates the timestamp on the page in realtime.